### PR TITLE
Avoid Deleting client.keys and wazuh-agent logs on host. 

### DIFF
--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/ossec.log' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/logs/' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/log/*' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/*' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/logs/' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/logs' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/*' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/logs/ossec.log' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -8,6 +8,7 @@ let
   cfg = config.services.wazuh;
   pkg = config.services.wazuh.package;
   generatedConfig = import ./generate-agent-config.nix { cfg = config.services.wazuh; pkgs = pkgs; };
+  rsyncPath = "${pkgs.rsync}/bin";
 in {
   options = {
     services.wazuh = {
@@ -96,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        cp -rf ${pkg}/* ${stateDir}
+        rsync -av --exclude '/etc/client.keys' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/var/ossec/log/*' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;

--- a/nixos/modules/services/security/wazuh/wazuh.nix
+++ b/nixos/modules/services/security/wazuh/wazuh.nix
@@ -97,7 +97,7 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        rsync -av --exclude '/etc/client.keys' --exclude '/logs' ${pkg}/ ${stateDir}/
+        rsync -av --exclude '/etc/client.keys' --exclude '/logs/' ${pkg}/ ${stateDir}/
         cp ${generatedConfig} ${stateDir}/etc/ossec.conf
 
         find ${stateDir} -type f -exec chmod 644 {} \;


### PR DESCRIPTION
## Description of changes

Implemented rysnc to maintain client.keys intact. 

Prior to this, client.keys was overwritten due to the use of `cp -rf`. This was noted on a reboot of my test machine. The agent was then unable to register with the manager server due to a name collision. 

I tested this on a reboot and rebuild. 


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
